### PR TITLE
Add max weekly online chart

### DIFF
--- a/internal/controller/master.go
+++ b/internal/controller/master.go
@@ -111,6 +111,8 @@ func initializeRoutes() {
 
 		apiRoute.GET("/online_stat_weeks", api.OnlineStatWeeksGET)
 
+		apiRoute.GET("/online_stat_weeks_max", api.OnlineStatWeeksMaxGET)
+
 		apiRoute.GET("/online_stat_daytime", api.OnlineStatByDaytimeGET)
 
 		apiRoute.GET("/chronicles_daytime", api.ChronicleByDatetimeGET)

--- a/internal/service/stats/api/api.go
+++ b/internal/service/stats/api/api.go
@@ -677,6 +677,53 @@ func OnlineStatWeeksGET(c *gin.Context) {
 	c.JSON(http.StatusOK, onlineStat)
 }
 
+func OnlineStatWeeksMaxGET(c *gin.Context) {
+	type Dates struct {
+		DateFrom string `form:"dateFrom"`
+		DateTo   string `form:"dateTo"`
+	}
+
+	var query Dates
+	if err := c.BindQuery(&query); err != nil || query.DateFrom == "" || query.DateTo == "" {
+		c.JSON(http.StatusBadRequest, "Некорректный запрос.")
+		return
+	}
+
+	_, errFrom := time.Parse("2006-01-02", query.DateFrom)
+	_, errTo := time.Parse("2006-01-02", query.DateTo)
+	if errFrom != nil || errTo != nil {
+		c.JSON(http.StatusBadRequest, "Некорректно введена дата.")
+		return
+	}
+
+	var dbResult []struct {
+		WeekDate string
+		Players  int
+	}
+
+	r.Database.Raw(`
+		select date_part('isoyear', date) || '-' || date_part('week', date) as week_date, max(s.crew_total) as players
+		from roots
+		join scores s on round_id = s.root_id
+		where (date >= ? and date <= ?) 
+		group by week_date
+		order by to_date(date_part('isoyear', date) || '-' || date_part('week', date), 'YYYY-WW');
+		`, query.DateFrom, query.DateTo).Scan(&dbResult)
+
+	onlineStat := make(map[string]int, len(dbResult))
+
+	for _, onlineDay := range dbResult {
+		date := strings.Split(onlineDay.WeekDate, "-")
+		if len(date[1]) == 1 {
+			date[1] = "0" + date[1]
+		}
+		onlineStat[fmt.Sprintf("%s-%s", date[0], date[1])] = onlineDay.Players
+	}
+
+	c.JSON(http.StatusOK, onlineStat)
+}
+
+
 func OnlineStatByDaytimeGET(c *gin.Context) {
 	type Dates struct {
 		DateFrom string `form:"dateFrom"`

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -37,7 +37,7 @@
                 </div>
             </div>
             <div class="row">
-                <h5 class="text-center border-bottom pb-2">Средний онлайн по неделям</h5>
+                <h5 class="text-center border-bottom pb-2">Онлайн по неделям</h5>
                 <canvas id="online-stat-all-weeks"></canvas>
             </div>
             <div class="row">
@@ -273,6 +273,7 @@
         await getChronicles()
 
         await get_online_chart("online-stat-all-weeks", "online_stat_weeks", "players, avg", menuDateStart, menuDateEnd)
+        await get_online_chart("online-stat-all-weeks", "online_stat_weeks_max", "players, max", menuDateStart, menuDateEnd)
         await get_online_chart("online-stat-daytime", "online_stat_daytime", "players, avg", menuDateStart, menuDateEnd)
 
         const dateTo = new Date()


### PR DESCRIPTION
Добавил на график онлайна по неделям график макс. онлайна. По этому поводу переименовал график на "Онлайн по неделям". Всё нейрослоп через gemini 3.1
<img width="1456" height="853" alt="image" src="https://github.com/user-attachments/assets/67c18c1f-77e4-47c6-9868-e6cfcab31d21" />
